### PR TITLE
parser was modified

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -119,7 +119,7 @@ variables_msg:   /* empty */
 					message_variables[n_messages] = res;
                                       };
 
-msg_packet: variables_msg NEWLINE MINUS NEWLINE {n_messages++}
+msg_packet: variables_msg NEWLINE MINUS NEWLINE {n_messages++;}
 
 
 msg_separation:  variables_msg NEWLINE 


### PR DESCRIPTION
Dear Prof. Bouillaguet,

Thanks a lot for sharing this code. There was a small typo in parser.y which caused an error in compile time. However, it was solved by just adding a semicolon in line 122. 

Best regards, 
Hosein